### PR TITLE
Add support for non-standard rpc urls (e.g. for gerrit 1.5+)

### DIFF
--- a/gerrit/rpc.py
+++ b/gerrit/rpc.py
@@ -9,8 +9,8 @@ from urlparse import urljoin
 
 
 class Client(object):
-    def __init__(self, host):
-        self.host = urljoin(host, 'gerrit/rpc')
+    def __init__(self, host, rpc_path='gerrit/rpc'):
+        self.host = urljoin(host, rpc_path)
         self.connection = service.Connection(self.host)
 
     def _paginate(self, method, *args, **kwargs):


### PR DESCRIPTION
In Gerrit 1.5.1, the RPC endpoint was moved from 'gerrit/rpc' to 'gerrit_ui/rpc' _and_ marked as deprecated. This change adds a parameter to the Client constructor to allow setting the endpoint path manually.
